### PR TITLE
Fix serial tty setup for modern Linux

### DIFF
--- a/src/tty.c
+++ b/src/tty.c
@@ -55,9 +55,14 @@ int tty_open(const char *name) {
 	ioctl(fd, TIOCEXCL, NULL);
 
 	struct termios newtio;
-	bzero(&newtio, sizeof(newtio));
-	newtio.c_cflag = B230400 | CS8 | CLOCAL | CREAD | CRTSCTS;
-	//cfmakeraw(&newtio);
+	memset(&newtio, 0, sizeof(newtio));
+	cfmakeraw(&newtio);
+	cfsetispeed(&newtio, B230400);
+	cfsetospeed(&newtio, B230400);
+	newtio.c_cflag |= CS8 | CLOCAL | CREAD;
+	/* Modern FTDI/USB-serial adapters are more reliable without CRTSCTS.
+	 * The microHam protocol is binary and does not need hardware flow control. */
+	newtio.c_cflag &= ~CRTSCTS;
 	int err = tcsetattr(fd, TCSANOW, &newtio);
 
 	if(err) {


### PR DESCRIPTION
## Summary
This PR updates serial TTY initialization in `src/tty.c` to improve reliability with modern Linux USB-serial adapters (especially FTDI based).

## What changed
- Replaced `bzero(&newtio, sizeof(newtio));` with `memset(&newtio, 0, sizeof(newtio));`.
- Enabled raw mode via `cfmakeraw(&newtio);` for binary protocol transport.
- Explicitly set both input and output baud rate to `B230400` using:
  - `cfsetispeed(&newtio, B230400);`
  - `cfsetospeed(&newtio, B230400);`
- Set required control flags with:
  - `newtio.c_cflag |= CS8 | CLOCAL | CREAD;`
- Disabled hardware flow control:
  - `newtio.c_cflag &= ~CRTSCTS;`

## Why
The previous setup depended on `CRTSCTS` and did not configure raw mode/speeds via termios helper APIs. On modern Linux/USB-serial setups this can cause unstable behavior. The microHam protocol is binary and does not require RTS/CTS flow control.

## Scope
- One file changed: `src/tty.c`
- Net diff: 8 insertions, 3 deletions

## Validation
- Built successfully with `make` on Linux after this change.
